### PR TITLE
Fixed enforceVMOwnership and vmQuotaPerUser functionality

### DIFF
--- a/endpoints/lib/vboxconnector.php
+++ b/endpoints/lib/vboxconnector.php
@@ -3749,15 +3749,15 @@ class vboxconnector {
 			if ( @isset($this->settings->vmQuotaPerUser) && @$this->settings->vmQuotaPerUser > 0 && !$_SESSION['admin'] )
 			{
 				$newresp = array('data' => array());
-				$vmlist = $this->vboxGetMachines(array(), $newresp);
-				if ( count($newresp['data']['vmlist']) >= $this->settings->vmQuotaPerUser )
+				$this->vboxGetMachines(array(), array(&$newresp));
+				if ( count($newresp['data']['responseData']) >= $this->settings->vmQuotaPerUser )
 				{
 					// we're over quota!
 					// delete the disk we just created
 					if ( isset($args['disk']) )
 					{
 						$this->mediumRemove(array(
-								'id' => $args['disk'],
+								'medium' => $args['disk'],
 								'type' => 'HardDisk',
 								'delete' => true
 							), $newresp);

--- a/js/datamediator.js
+++ b/js/datamediator.js
@@ -93,7 +93,7 @@ var vboxVMDataMediator = {
 			for(var i = 0; i < d.responseData.length; i++) {
 				
 				// Enforce VM ownership
-			    if($('#vboxPane').data('vboxConfig').enforceVMOwnership && !$('#vboxPane').data('vboxSession').admin && d.vmlist[i].owner != $('#vboxPane').data('vboxSession').user) {
+			    if($('#vboxPane').data('vboxConfig').enforceVMOwnership && !$('#vboxPane').data('vboxSession').admin && d.responseData[i].owner != $('#vboxPane').data('vboxSession').user) {
 			    	continue;
 			    }
 


### PR DESCRIPTION
#These features are broken in 5.0-5.
When "enforceVMOwnership" is enabled and you log in with non-admin user account, the VM list panel is stuck in "Loading..." stage.
"vmQuotaPerUser" is simply ignored.

This fix resolves both issues.