### PR TITLE
Add VBoxAuthSimple

### DIFF
--- a/config.php-example
+++ b/config.php-example
@@ -218,7 +218,21 @@ LPT support may or may not work for you.
 #var $eventListenerTimeout = 20;
 
 /* END SETTINGS  */
+  public function phpVBoxConfig() {    
+    if($this->authLib == 'VBoxAuthSimple') {
+      session_start();
+      $this->username = $this->getUsername();
+      $this->password = $this->getPassword();
+    }
+  }
 
+  public function getUsername() {
+    return $_SESSION['user'];
+  }
+
+  public function getPassword() {
+    return $_SESSION['password'];
+  }
 
 }
 

--- a/endpoints/lib/auth/VBoxAuthSimple.php
+++ b/endpoints/lib/auth/VBoxAuthSimple.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @author Audun Larsen (larsen at xqus dot com)
+ * @copyright Copyright (C) 2014 Audun Larsen (larsen at xqus dot com)
+ * @link http://xqus.com/blog/phpvirtbox-vboxauthsimple
+ * @package phpVirtualBox
+ * @see vboxconnector
+ * @see ajax.php
+ *
+ */
+class phpvbAuthVBoxAuthSimple implements phpvbAuth {
+
+  /**
+   * A list of capabilities describing this authentication module.
+   */
+  var $capabilities = array(
+    'canChangePassword' => false,
+    'canModifyUsers' => false,
+    'canLogout' => true,
+  );
+
+  /**
+   * Log in function. Populates $_SESSION.
+   *
+   * @param string $username user name
+   * @param string $password password
+   */
+  function login($username, $password) {
+    $vbox = new vboxconnector(true);
+
+    $vbox->skipSessionCheck = true;
+
+    $vbox->settings->username = $username;
+    $vbox->settings->password = $password;
+
+    $vbox->connect();
+
+    if($vbox->connected == true) {
+      $_SESSION['valid'] = true;
+      $_SESSION['user'] = $username;
+      $_SESSION['password'] = $password;
+      $_SESSION['authCheckHeartbeat'] = time();
+
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Change password function.
+   *
+   * @param string $old old password
+   * @param string $new new password
+   * @return boolean true on success
+   */
+  function changePassword($old, $new) {
+
+  }
+
+  /**
+   * Revalidate login info and set authCheckHeartbeat session variable.
+   *
+   * @param vboxconnector $vbox vboxconnector object instance
+   */
+  function heartbeat($vbox) {
+    $_SESSION['valid'] = true;
+    $_SESSION['authCheckHeartbeat'] = time();
+  }
+
+  /**
+   * Log out user present in $_SESSION.
+   *
+   * @param array $response response passed byref by ajax.php and populated within function
+   */
+  function logout(&$response) {
+    $_SESSION = array();
+    $response['data']['result'] = 1;
+  }
+
+  /**
+   * Return a list of users.
+   *
+   * @return array list of users
+   */
+  function listUsers() {
+
+  }
+
+  /**
+   *
+   * Update user information such as password and admin status
+   * @param array $vboxRequest request passed from ajax.php representing the ajax request. Contains user, password and administration level.
+   * @param boolean $skipExistCheck Do not check that the user exists first. Essentially, if this is set and the user does not exist, it is added.
+   */
+  function updateUser($vboxRequest, $skipExistCheck) {
+
+  }
+
+  /**
+   *
+   * Remove the user $user
+   * @param string $user Username to remove
+   */
+  function deleteUser($user) {
+
+  }
+
+}


### PR DESCRIPTION
Adds VBoxAuthSimple so we don't have to store username and password in plain text.

To set up Virtualbox:
**Configure VurtualBox web server to use VBoxAuthSimple.**
$ VBoxManage setproperty websrvauthlibrary "VBoxAuthSimple"

**Create a password hash.**
$ VBoxManage internalcommands passwordhash "secret"

**Add a user to the VirtualBox config. Username: username, with password: secret.**
$ VBoxManage setextradata global "VBoxAuthSimple/users/username" / 2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b`

**Set VBoxAuthSimple as authentication library**
var $authLib = 'VBoxAuthSimple';