### PR TITLE
Fixed invalid new HDD path issue when enforceVMOwnership is enabled

### DIFF
--- a/panes/wizardNewHD.html
+++ b/panes/wizardNewHD.html
@@ -269,7 +269,7 @@ $('#wizardNewHDStep1').on('show',function(e,wiz){
 		$('#wizardNewHDSize').slider('value',wiz.suggested.size);
 	}
 	
-	if(wiz.suggested.path){
+	if(wiz.suggested.path && wiz.suggested.name){
 		if($('#vboxPane').data('vboxConfig').enforceVMOwnership==true){
 			var nameIndex = wiz.suggested.path.lastIndexOf(wiz.suggested.name+$('#vboxPane').data('vboxConfig').DSEP);
 			var path = wiz.suggested.path.substr(0,nameIndex);

--- a/panes/wizardNewHDAdvanced.html
+++ b/panes/wizardNewHDAdvanced.html
@@ -229,7 +229,7 @@ $('#wizardNewHDStep1').on('show',function(e,wiz){
 		$('#wizardNewHDSize').slider('value',wiz.suggested.size);
 	}
 	
-	if(wiz.suggested.path){
+	if(wiz.suggested.path && wiz.suggested.name){
 		if($('#vboxPane').data('vboxConfig').enforceVMOwnership==true){
 			var nameIndex = wiz.suggested.path.lastIndexOf(wiz.suggested.name+$('#vboxPane').data('vboxConfig').DSEP);
 			var path = wiz.suggested.path.substr(0,nameIndex);


### PR DESCRIPTION
When enforceVMOwnership is enabled and user is trying to create a new HDD, incorrect path is constructed, e.g. <username>_undefined/<vm-name>N.vdi
